### PR TITLE
Added Dotnet Test Container to remove the need for external Docker container setup

### DIFF
--- a/src/Marten.AspNetIdentity.Tests/Integration/DocumentStoreManager.cs
+++ b/src/Marten.AspNetIdentity.Tests/Integration/DocumentStoreManager.cs
@@ -8,7 +8,7 @@ namespace Marten.AspNetIdentity.Tests.Integration
 		private static readonly ConcurrentDictionary<string, IDocumentStore> _documentStores = new ConcurrentDictionary<string, IDocumentStore>();
 		public static string ConnectionString => "host=localhost;port=5432;database=aspnetidentity;username=aspnetidentity;password=aspnetidentity;";
 
-		public static IDocumentStore GetMartenDocumentStore(Type testClassType)
+		public static IDocumentStore GetMartenDocumentStore(Type testClassType, string connectionString = null)
 		{
 			string documentStoreSchemaName = "";
 
@@ -17,7 +17,7 @@ namespace Marten.AspNetIdentity.Tests.Integration
 
 			if (!_documentStores.ContainsKey(documentStoreSchemaName))
 			{
-				IDocumentStore docStore = Extensions.CreateDocumentStore(ConnectionString, documentStoreSchemaName);
+				IDocumentStore docStore = Extensions.CreateDocumentStore(connectionString ?? ConnectionString, documentStoreSchemaName);
 				_documentStores.TryAdd(documentStoreSchemaName, docStore);
 			}
 

--- a/src/Marten.AspNetIdentity.Tests/Integration/MartenRoleStoreTests.cs
+++ b/src/Marten.AspNetIdentity.Tests/Integration/MartenRoleStoreTests.cs
@@ -11,24 +11,18 @@ using Xunit.Abstractions;
 
 namespace Marten.AspNetIdentity.Tests.Integration
 {
-	public class MartenRoleStoreTests
+	public class MartenRoleStoreTests : IClassFixture<PostgresSqlFixture>
 	{
-		//
-		// These tests require a postgres server, the Docker command is:
-		//
-		// $> docker run -d -p 5432:5432 --name aspnetidentity-postgres -e POSTGRES_USER=aspnetidentity -e POSTGRES_PASSWORD=aspnetidentity postgres
-		//
-
 		private readonly ITestOutputHelper _testOutputHelper;
 		private MartenRoleStore<IdentityRole> _roleStore;
 		private Fixture _fixture;
 
-		public MartenRoleStoreTests(ITestOutputHelper testOutputHelper)
+		public MartenRoleStoreTests(ITestOutputHelper testOutputHelper, PostgresSqlFixture postgresSqlFixture)
 		{
 			_testOutputHelper = testOutputHelper;
 			_fixture = new Fixture();
 
-			var store = DocumentStoreManager.GetMartenDocumentStore(typeof(MartenRoleStoreTests));
+			var store = DocumentStoreManager.GetMartenDocumentStore(typeof(MartenRoleStoreTests), postgresSqlFixture.ConnectionString);
 			_roleStore = new MartenRoleStore<IdentityRole>(store, new NullLogger<MartenRoleStore<IdentityRole>>());
 		}
 

--- a/src/Marten.AspNetIdentity.Tests/Integration/MartenUserStoreTests.cs
+++ b/src/Marten.AspNetIdentity.Tests/Integration/MartenUserStoreTests.cs
@@ -12,16 +12,16 @@ using Xunit.Abstractions;
 
 namespace Marten.AspNetIdentity.Tests.Integration
 {
-	public class MartenUserStoreTests
+	public class MartenUserStoreTests : IClassFixture<PostgresSqlFixture>
 	{
 		private readonly ITestOutputHelper _testOutputHelper;
 		private MartenUserStore<TestUser> _userStore;
 
-		public MartenUserStoreTests(ITestOutputHelper testOutputHelper)
+		public MartenUserStoreTests(ITestOutputHelper testOutputHelper, PostgresSqlFixture postgresSqlFixture)
 		{
 			_testOutputHelper = testOutputHelper;
 
-			var store = DocumentStoreManager.GetMartenDocumentStore(typeof(MartenUserStoreTests));
+			var store = DocumentStoreManager.GetMartenDocumentStore(typeof(MartenUserStoreTests), postgresSqlFixture.ConnectionString);
 			_userStore = new MartenUserStore<TestUser>(store, new NullLogger<MartenUserStore<TestUser>>());
 			_userStore.Wipe();
 		}

--- a/src/Marten.AspNetIdentity.Tests/Marten.AspNetIdentity.Tests.csproj
+++ b/src/Marten.AspNetIdentity.Tests/Marten.AspNetIdentity.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+    <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Marten.AspNetIdentity.Tests/PostgresSqlFixture.cs
+++ b/src/Marten.AspNetIdentity.Tests/PostgresSqlFixture.cs
@@ -1,0 +1,46 @@
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Containers.Builders;
+using DotNet.Testcontainers.Containers.Configurations.Databases;
+using DotNet.Testcontainers.Containers.Modules.Databases;
+using Xunit;
+
+namespace Marten.AspNetIdentity.Tests
+{
+    public class PostgresSqlFixture : IAsyncLifetime
+    {
+        private readonly PostgreSqlTestcontainer _testContainer;
+        
+        public PostgresSqlFixture()
+        {
+            var testContainerBuilder = new TestcontainersBuilder<PostgreSqlTestcontainer>()
+                .WithCleanUp(true)
+                .WithDatabase(new PostgreSqlTestcontainerConfiguration
+                {
+                    Database = "aspnetidentity",
+                    Username = "aspnetidentity",
+                    Password = "aspnetidentity"
+                })
+                .WithImage("clkao/postgres-plv8");
+
+            _testContainer = testContainerBuilder.Build();
+        }
+
+        public string ConnectionString => _testContainer.ConnectionString;
+        
+        public async Task InitializeAsync()
+        {
+            await _testContainer.StartAsync();
+
+            var result = await _testContainer.ExecAsync(new[]
+            {
+                "/bin/sh", "-c",
+                "psql -U aspnetidentity -c \"CREATE EXTENSION plv8; SELECT extversion FROM pg_extensions WHERE extname = 'plv8';\""
+            });
+        }
+
+        public async Task DisposeAsync()
+        {
+            await _testContainer.StopAsync();
+        }
+    }
+}


### PR DESCRIPTION
I was looking to use this but noticed the integration tests needed an external container set up, so added [Dotnet Test Containers](https://github.com/HofmeisterAn/dotnet-testcontainers) as a class fixture so that all the integration tests can access the container.