### PR TITLE
Add net10 build target

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<PropertyGroup>
 		<!-- Common properties for all projects -->
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<Nullable>disable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/src/Marten.AspNetIdentity/Marten.AspNetIdentity.csproj
+++ b/src/Marten.AspNetIdentity/Marten.AspNetIdentity.csproj
@@ -5,12 +5,31 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Marten" Version="8.13.1" />
+		<PackageReference Include="Marten" Version="8.16.4" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Added build targets for net8.0, net9.0, and net10.0. This should keep backwards compatibility with the existing net9.0 version, and adds support for net10.0.  

Updated target version of Marten that also provides the net10.0 build target