### PR TITLE
Fix parallel integration test execution for all frameworks

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,9 +21,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: .NET - setup
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.x'
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: .NET - restore & Build
         run: dotnet build

--- a/docker/startup.sql
+++ b/docker/startup.sql
@@ -1,3 +1,15 @@
 CREATE database aspnetidentity;
 CREATE USER aspnetidentity WITH PASSWORD 'aspnetidentity';
 ALTER USER aspnetidentity WITH SUPERUSER;
+
+CREATE DATABASE aspnetidentity_net8;
+CREATE USER aspnetidentity_net8 WITH PASSWORD 'aspnetidentity';
+ALTER USER aspnetidentity_net8 WITH SUPERUSER;
+
+CREATE DATABASE aspnetidentity_net9;
+CREATE USER aspnetidentity_net9 WITH PASSWORD 'aspnetidentity';
+ALTER USER aspnetidentity_net9 WITH SUPERUSER;
+
+CREATE DATABASE aspnetidentity_net10;
+CREATE USER aspnetidentity_net10 WITH PASSWORD 'aspnetidentity';
+ALTER USER aspnetidentity_net10 WITH SUPERUSER;

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "9.0.305",
-    "rollForward": "latestMinor"
-  }
-}

--- a/src/Marten.AspNetIdentity.Tests/Integration/DocumentStoreManager.cs
+++ b/src/Marten.AspNetIdentity.Tests/Integration/DocumentStoreManager.cs
@@ -6,7 +6,18 @@ namespace Marten.AspNetIdentity.Tests.Integration
 	public class DocumentStoreManager
 	{
 		private static readonly ConcurrentDictionary<string, IDocumentStore> _documentStores = new ConcurrentDictionary<string, IDocumentStore>();
-		public static string ConnectionString => "host=localhost;port=5432;database=aspnetidentity;username=aspnetidentity;password=aspnetidentity;";
+		public static string ConnectionString => $"host=localhost;port=5432;database={DbName};username=aspnetidentity;password=aspnetidentity;";
+
+		private static string DbName =>
+		#if NET10_0
+			"aspnetidentity_net10";
+		#elif NET9_0
+			"aspnetidentity_net9";
+		#elif NET8_0
+			"aspnetidentity_net8";
+		#else
+			"aspnetidentity";
+		#endif
 
 		public static IDocumentStore GetMartenDocumentStore(Type testClassType, string connectionString = null)
 		{


### PR DESCRIPTION
It turns out that running `dotnet test` without specifying a target framework fails, as there are multiple instances of the same integration test targeting the same database running at the same time.  

This could be fixed by running the tests for each framework individually, or by making each framework build target a different database. I have chosen the latter. Let me know if you have any better ideas.